### PR TITLE
Activate the first stack frame on stack trace reception

### DIFF
--- a/src/codeviewer.cpp
+++ b/src/codeviewer.cpp
@@ -536,8 +536,8 @@ void CodeViewer::stackTraceReceived(QVector<Debugger::StackFrame> &frames)
 	}
 
 	// activate current function
-	frameSelector->setCurrentIndex(frameSelector->count() - 1);
-	stackFrameChanged(stackTrace.size() - 1);
+	frameSelector->setCurrentIndex(0);
+	stackFrameChanged(0);
 }
 
 void CodeViewer::stackFrameChanged(int i)


### PR DESCRIPTION
After nunuhara/xsystem4@5576f14, xsystem4 returns most recent call first.